### PR TITLE
Fixed the fetch script

### DIFF
--- a/scripts/fetch
+++ b/scripts/fetch
@@ -8,7 +8,7 @@ for j in c b; do
 done
 
 user=$(whoami)
-host=$(hostname)
+host=$(uname -a | awk '{print $2}')
 memory=$(free -h)
 os=$(source /etc/os-release && echo $PRETTY_NAME)
 kernel=$(uname -sr)
@@ -46,7 +46,6 @@ init() {
 init
 
 cat <<EOF
-
 ${c0} ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 ${c0} ▎▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▎ ${c2} ${c0} ${c3} ${c0}${c1}  ${c0}▎ ${c1}${c4}${c1} ${c4}$user@${c1}$host
 ${c0} ▎                            ▎ ${c4}
@@ -57,10 +56,8 @@ ${c0} ▎        ${c0}█         █${c0}         ▎ ${c4}Shell  ${c7} $shell
 ${c0} ▎        ${c0}▀█▄▄▄▄▄▄▄█▀${c0}         ▎ ${c4}Init   ${c7} $init
 ${c0} ▎                            ▎ ${c4}pkgs   ${c7} $pkgs
 ${c0} ▎                            ▎ ${c4}uptime ${c7} $(get_uptime)
-${c0} ▎   ${c4}void    runit ^_^    ${c0} ▎ ${c4}memory ${c7} $mem $(echo / 3776MiB) 
+${c0} ▎   ${c4}void    runit ^_^    ${c0} ▎ ${c4}memory ${c7} $mem $(echo / 3776MiB)
 ${c0} ▎▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▎ $colors
-
-
 EOF
 
 if [[ $1 == "-b" ]]; then


### PR DESCRIPTION
The fetch script had the hostname variable, and its broken/does not work well. I fixed it by just adding `uname -a | awk '{print $2}'`