### PR TITLE
Fixed shortcut conflict in config.def.h

### DIFF
--- a/chadwm/config.def.h
+++ b/chadwm/config.def.h
@@ -153,7 +153,7 @@ static Key keys[] = {
     { MODKEY|ShiftMask,             XK_o,      setcfact,       {.f =  0.00} },
     { MODKEY|ShiftMask,             XK_j,      movestack,      {.i = +1 } },
     { MODKEY|ShiftMask,             XK_k,      movestack,      {.i = -1 } },
-    { MODKEY,                       XK_Return, zoom,           {0} },
+    { MODKEY|ShiftMask,             XK_Return, zoom,           {0} },
     { MODKEY,                       XK_Tab,    view,           {0} },
 
     // overall gaps

--- a/keyssheet.md
+++ b/keyssheet.md
@@ -1,22 +1,22 @@
-## Windows Keys                                     
-key               | Do         | Value
------------------ | ---------- | ------
- win + b          | togglebar  |   0   
- win + ctrl + w   | tabmode    |  -1
- win + j          | focusstack |  +1
- win + k          | focusstack |  -1
- win + i          | incnmaster |  +1
- win + d          | incnmaster |  -1 
- win + h          | setmfact   |  -0.05
- win + l          | setmfact   |  +0.05
- win + shift + h  | setcfact   |  +0.25
- win + shift + l  | setcfact   |  -0.25
- win + shift + o  | setcfact   |   0.00
- win + shift + j  | movestack  |  +1 
- win + shift + k  | movestack  |  -1 
- win + Return     | zoom       |   0
- win + Tab        | view       |   0
- 
+## Windows Keys
+key                    | Do         | Value
+---------------------- | ---------- | ------
+ win + b               | togglebar  |   0
+ win + ctrl + w        | tabmode    |  -1
+ win + j               | focusstack |  +1
+ win + k               | focusstack |  -1
+ win + i               | incnmaster |  +1
+ win + d               | incnmaster |  -1
+ win + h               | setmfact   |  -0.05
+ win + l               | setmfact   |  +0.05
+ win + shift + h       | setcfact   |  +0.25
+ win + shift + l       | setcfact   |  -0.25
+ win + shift + o       | setcfact   |   0.00
+ win + shift + j       | movestack  |  +1
+ win + shift + k       | movestack  |  -1
+ win + shift + Return  | zoom       |   0
+ win + Tab             | view       |   0
+
 ##  Overall gaps
 key             | Do         | Value
 --------------- | ---------- | ------


### PR DESCRIPTION
Terminal spawn & zoom were mapped to the same key combination.
Moved zoom to Win + Shift + Return.