### PR TITLE
Update config.def.h - cyclelayouts crash

### DIFF
--- a/chadwm/config.def.h
+++ b/chadwm/config.def.h
@@ -108,6 +108,7 @@ static const Layout layouts[] = {
     { "|M|",      centeredmaster },
     { ">M>",      centeredfloatingmaster },
     { "><>",      NULL },    /* no layout function means floating behavior */
+    { NULL,       NULL },
 };
 
 /* key definitions */


### PR DESCRIPTION
DWM will crashed after cycle through layouts `><>`,
If `NULL, NULL` not being set, layout after `><>` will be shown as the name of first Rule. Most of the time DWM will crash and force use to logout.

Add `NULL, NULL` at the end of the layouts to avoid crash when cycle through layouts.

It is also instructed on the patch page.
[dwm patch](https://dwm.suckless.org/patches/cyclelayouts/)
