### PR TITLE
replace `pacman` with `checkupdates` for checking updates in arch

### DIFF
--- a/scripts/bar.sh
+++ b/scripts/bar.sh
@@ -17,7 +17,7 @@ cpu() {
 
 pkg_updates() {
   updates=$(doas xbps-install -un | wc -l) # void
-  # updates=$(pacman -Qu | wc -l)   # arch
+  # updates=$(checkupdates | wc -l)   # arch
   # updates=$(aptitude search '~U' | wc -l)  # apt (ubuntu,debian etc)
 
   if [ -z "$updates" ]; then


### PR DESCRIPTION
use `checkupdates` for getting number of packages to update, because `pacman` requires user to be root, whereas `checkupdates` can be ran without any root level permissions.
![image](https://user-images.githubusercontent.com/70624701/178140863-c90a2827-6ff9-4ed2-b9ab-f9b7c41a15f5.png)
