### PR TITLE
Applied shiftview patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,4 @@ eww open eww
 - notitle
 - winicon
 - [preserveonrestart](https://github.com/PhyTech-R0/dwm-phyOS/blob/master/patches/dwm-6.3-patches/dwm-preserveonrestart-6.3.diff). This patch doesnt let all windows mix up into tag 1 after restarting dwm.
+- shiftview

--- a/chadwm/config.def.h
+++ b/chadwm/config.def.h
@@ -165,6 +165,10 @@ static const Key keys[] = {
     { MODKEY,                           XK_i,       incnmaster,     {.i = +1 } },
     { MODKEY,                           XK_d,       incnmaster,     {.i = -1 } },
 
+    // shift view
+    { MODKEY,                           XK_Left,    shiftview,      {.i = -1 } },
+    { MODKEY,                           XK_Right,   shiftview,      {.i = +1 } },
+
     // change m,cfact sizes 
     { MODKEY,                           XK_h,       setmfact,       {.f = -0.05} },
     { MODKEY,                           XK_l,       setmfact,       {.f = +0.05} },

--- a/chadwm/dwm.c
+++ b/chadwm/dwm.c
@@ -445,6 +445,7 @@ struct Monitor {
 
 #include "vanitygaps.c"
 #include "movestack.c"
+#include "shiftview.c"
 
 struct Pertag {
 	unsigned int curtag, prevtag; /* current and previous tag */

--- a/chadwm/functions.h
+++ b/chadwm/functions.h
@@ -28,3 +28,4 @@ static void getfacts(Monitor *m, int msize, int ssize, float *mf, float *sf, int
 static void setgaps(int oh, int ov, int ih, int iv);
 
 static void movestack(const Arg *arg);
+static void shiftview(const Arg *arg);

--- a/chadwm/shiftview.c
+++ b/chadwm/shiftview.c
@@ -1,0 +1,24 @@
+/**
+ * Author: Fernando C.V.
+ * http://lists.suckless.org/dev/1104/7590.html
+ */
+
+/** Function to shift the current view to the left/right
+ *
+ * @param: "arg->i" stores the number of tags to shift right (positive value)
+ *          or left (negative value)
+ */
+void
+shiftview(const Arg *arg) {
+  Arg shifted;
+ 
+  if(arg->i > 0) // left circular shift
+    shifted.ui = (selmon->tagset[selmon->seltags] << arg->i)
+      | (selmon->tagset[selmon->seltags] >> (LENGTH(tags) - arg->i));
+ 
+  else // right circular shift
+    shifted.ui = selmon->tagset[selmon->seltags] >> (- arg->i)
+      | selmon->tagset[selmon->seltags] << (LENGTH(tags) + arg->i);
+ 
+  view(&shifted);
+}


### PR DESCRIPTION
I deleted the previous PR before updating to 6.4, so here it is again. This patch switches to the left/right tag, with Super + Left/Right arrow keys.