### PR TITLE
fix: nixos specific no such file or directory

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,5 +6,5 @@ feh --bg-fill ~/Pictures/wall/gruv.png &
 xset r rate 200 50 &
 picom &
 
-~/.config/chadwm/scripts/bar.sh &
+dash ~/.config/chadwm/scripts/bar.sh &
 while type chadwm >/dev/null; do chadwm && continue || break; done


### PR DESCRIPTION
I was getting no such file or directory errors in NixOS.

It turns out that the shebang was causing this error.

To address this problem, this PR explicitly tells the OS to execute the script using dash

> [!NOTE]
> this will make it easier to spot people who did not install `dash` and complaining about the bar is not working