### PR TITLE
Fixed window attach at the end for multi monitor setup

### DIFF
--- a/chadwm/dwm.c
+++ b/chadwm/dwm.c
@@ -590,6 +590,7 @@ void arrangemon(Monitor *m) {
 
 void attach(Client *c) {
   if(new_window_attach_on_end){
+    c->next = NULL;
     Client**tmp = &c->mon->clients;
     while(*tmp)tmp = &(*tmp)->next;
     *tmp = c;


### PR DESCRIPTION
Not resetting c->next with multi monitors creates an endless loop and crashes.

## Step to reproduce:
1) Set config `static const int new_window_attach_on_end = 1;` 
1) Open one client in each monitor
1) Move one of the clients to the other monitor
1) Move back a client to the first window 
 -> Start crashing => ctrl+alt+f3 to kill chadwm

## Fix:
Reset the client chained list:
```c
c->next = NULL
```